### PR TITLE
Normalize head partial metadata and icons

### DIFF
--- a/partials/head.html
+++ b/partials/head.html
@@ -1,35 +1,35 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <!-- Open Graph -->
-  <meta property="og:title" content="Bali WebDevelover - Professional Website Services">
-  <meta property="og:description" content="Kami membantu bisnis Anda tampil profesional di dunia digital dengan website modern, cepat, dan elegan.">
-  <meta property="og:image" content="https://bali-webdevelover.com/assets/img/logos/ogimg.png">
-  <meta property="og:url" content="https://bali-webdevelover.com/">
-  <meta property="og:type" content="website">
+<title>Bali WebDevelover - Professional Website Services</title>
+<meta name="description" content="Kami membantu bisnis Anda tampil profesional di dunia digital dengan website modern, cepat, dan elegan.">
+<link rel="canonical" href="https://bali-webdevelover.com/">
 
-  <!-- Twitter Card -->
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Bali WebDevelover - Professional Website Services">
-  <meta name="twitter:description" content="Website modern, cepat, dan elegan untuk bisnis Anda.">
-  <meta name="twitter:image" content="https://bali-webdevelover.com/assets/img/logos/ogimg.png">
+<!-- Open Graph -->
+<!-- og:image must be reachable and ideally 1200×630. Keep absolute URLs for OG/Twitter images and og:url. -->
+<meta property="og:title" content="Bali WebDevelover - Professional Website Services">
+<meta property="og:description" content="Kami membantu bisnis Anda tampil profesional di dunia digital dengan website modern, cepat, dan elegan.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://bali-webdevelover.com/">
+<meta property="og:image" content="https://bali-webdevelover.com/assets/img/logos/ogimg.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="Bali WebDevelover — preview gambar">
+<meta property="og:site_name" content="Bali WebDevelover">
+<meta property="og:locale" content="id_ID">
 
-  <!-- Favicon -->
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/img/logos/favicon.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/assets/img/logos/favicon.png">
-  <link rel="shortcut icon" href="/favicon.ico"> <!-- fallback -->
+<!-- Twitter Card -->
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Bali WebDevelover - Professional Website Services">
+<meta name="twitter:description" content="Kami membantu bisnis Anda tampil profesional di dunia digital dengan website modern, cepat, dan elegan.">
+<meta name="twitter:image" content="https://bali-webdevelover.com/assets/img/logos/ogimg.png">
 
-  <!-- Apple/Android -->
-  <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png">
-  <link rel="manifest" href="/site.webmanifest">
-  <meta name="theme-color" content="#8B5E34">
+<!-- Icons -->
+<link rel="icon" type="image/png" sizes="32x32" href="/assets/img/logos/favicon.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/assets/img/logos/favicon.png">
+<link rel="shortcut icon" href="/favicon.ico">
+<link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png">
 
-  <title>Bali WebDevelover - Professional Website Services</title>
-</head>
-<body>
-  <!-- content here -->
-</body>
-</html>
+<!-- PWA -->
+<link rel="manifest" href="/site.webmanifest">
+<meta name="theme-color" content="#8B5E34">


### PR DESCRIPTION
## Summary
- convert the head partial into a pure head snippet without html/doctype wrappers
- normalize title, description, canonical, and social meta tags with consistent defaults
- consolidate favicon, apple icon, and PWA manifest/theme references

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb6ab302c48323999ee0ae6aab53a9