### PR TITLE
Fix logos and certs section structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,10 +129,10 @@
   </svg>
 </span>
 
-
-    <!-- Certification -->
     </div>
-     <section class="section container certs">
+    <!-- Certification -->
+    </section>
+    <section class="section container certs">
 
   <a
     class="cert"
@@ -191,10 +191,6 @@
     </div>
   </a>
 </section>
-
-
-</section>
-
 
 
     <section class="section container">


### PR DESCRIPTION
## Summary
- close the tech logos wrapper div before the certification comment and end the logos section before starting the certification section
- remove the stray section closing tag after the certifications block so the DOM hierarchy is consistent

## Testing
- npx htmlhint index.html *(fails: npm registry returned 403 Forbidden when downloading htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68cbabe100108323a0aa4c5c7933961c