### PR TITLE
Replace tech logo anchors with divs and update styles

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -101,7 +101,7 @@ ul.clean li{margin:.4rem 0;color:var(--muted)}
   padding: 24px 0;
 }
 
-.logo {
+.tech-logos .logo {
   flex: 0 1 auto;
   display: flex;
   align-items: center;
@@ -109,15 +109,6 @@ ul.clean li{margin:.4rem 0;color:var(--muted)}
   height: 48px;
 }
 
-.logo img {
-  max-height: 32px;       /* tinggi logo */
-  width: auto;
-  opacity: 0.9;           /* biar lebih soft */
-  transition: opacity .2s;
-}
-.logo img:hover {
-  opacity: 1;
-}
 .devices{
   position:relative;
   display:flex; align-items:flex-end; justify-content:center;
@@ -178,13 +169,13 @@ ul.clean li{margin:.4rem 0;color:var(--muted)}
   padding:20px;
   margin-top:24px;
 }
-.tech-logos svg{
+.tech-logos .logo svg{
   width:40px; height:40px;
   display:block;
   opacity:.9;
-  transition:.2s;
+  transition:opacity .2s, transform .2s;
 }
-.tech-logos svg:hover{
+.tech-logos .logo svg:hover{
   opacity:1;
   transform: translateY(-2px);
 }
@@ -252,8 +243,8 @@ ul.clean li{margin:.4rem 0;color:var(--muted)}
 .tech-logos { margin-top: 28px; }
 .certs     { margin-top: 36px; }
 
-.tech-logos svg { width:40px; height:40px; }
-@media (max-width:640px){ .tech-logos svg{ width:32px; height:32px; } }
+.tech-logos .logo svg { width:40px; height:40px; }
+@media (max-width:640px){ .tech-logos .logo svg{ width:32px; height:32px; } }
 
 section.certs .cert{
   display:flex; align-items:center; gap:14px;

--- a/index.html
+++ b/index.html
@@ -76,16 +76,16 @@
       <section class="section container logos">
          <div class="tech-logos">
     <!-- Tech stack -->
-    <span class="logo" aria-label="HTML5 logo" role="img">
+    <div class="logo" aria-label="HTML5 logo" role="img">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="32" height="32" aria-hidden="true">
     <path fill="#E34F26" d="M19 114L10 0h108l-9 114-45 14z"/>
     <path fill="#EF652A" d="M64 116l36-10 8-90H64z"/>
     <path fill="#EBEBEB" d="M64 52H45l-1-12h20V28H31l3 36h30zM64 92l-.1.03L49.9 88l-1-12H37l2 24 25 7z"/>
     <path fill="#FFF" d="M64 52v12h17l-1.6 18L64 92.03V104l25-7 3-36H64zm0-24v12h32l1-12z"/>
   </svg>
-</span>
+</div>
 
-    <span class="logo" aria-label="CSS3 logo" role="img">
+    <div class="logo" aria-label="CSS3 logo" role="img">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="32" height="32" aria-hidden="true">
     <path fill="#1572B6" d="M19 114L10 0h108l-9 114-45 14z"/>
     <path fill="#33A9DC" d="M64 116l36-10 8-90H64z"/>
@@ -93,17 +93,17 @@
     <path fill="#EBEBEB" d="M64 52v12h17l-1.6 18L64 92.03V104l25-7 3-36H64zm0-24v12h32l1-12z"/>
     <text x="50%" y="20%" text-anchor="middle" font-family="Arial, sans-serif" font-size="28" fill="#fff" font-weight="bold">CSS</text>
   </svg>
-</span>
+</div>
 
 
-    <span class="logo" aria-label="JavaScript logo" role="img">
+    <div class="logo" aria-label="JavaScript logo" role="img">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="32" height="32" aria-hidden="true">
     <path fill="#F7DF1E" d="M1.408 1.408h125.184v125.185H1.408z"/>
     <path d="M116.383 96.74c-.917-5.735-4.633-10.54-15.674-15.055-3.83-1.766-8.1-3.012-9.38-5.938-.452-1.69-.512-2.64-.226-3.67.82-3.325 4.784-4.355 7.93-3.42 2.028.678 3.947 2.237 5.092 4.724 5.402-3.498 5.4-3.495 9.164-5.936-1.393-2.153-2.14-3.13-3.07-4.05-3.3-3.68-7.768-5.568-14.95-5.428l-3.73.482c-3.57.89-6.96 2.745-8.963 5.26-5.976 6.777-4.266 18.633 2.987 23.51 7.14 5.34 17.613 6.553 18.97 11.54 1.318 6.53-4.8 8.63-10.867 7.884-4.48-.93-6.98-3.25-9.695-7.42l-9.16 5.28c1.05 2.3 2.19 3.34 3.998 5.34 8.51 8.63 29.91 8.2 33.77-4.86.16-.48 1.24-3.62.375-8.41zM68.27 37.41H56.3v43.9c0 9.35-.38 17.9-1.72 20.54-1.39 2.87-4.96 5.56-8.53 6.43-5.44 1.48-13.13 1.17-17.44-.33-4.37-1.63-6.91-3.91-9.6-7.21l-9.15 5.51c1.54 3.52 3.57 6.1 6.45 8.43 8.63 6.91 20.48 8.95 32.86 5.27 8.02-2.33 14.24-7.1 17.7-14.34 3.26-6.4 2.87-14.23 2.84-22.81.08-23.53.01-47.07.01-70.6z"/>
   </svg>
-</span>
+</div>
 
-    <span class="logo" aria-label="React logo" role="img">
+    <div class="logo" aria-label="React logo" role="img">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="32" height="32" aria-hidden="true">
     <circle cx="64" cy="64" r="11.4" fill="#61DAFB"/>
     <g stroke="#61DAFB" stroke-width="6" fill="none">
@@ -112,22 +112,22 @@
       <ellipse rx="56" ry="22" cx="64" cy="64" transform="rotate(120 64 64)"/>
     </g>
   </svg>
-</span>
+</div>
 
-    <span class="logo" aria-label="WordPress logo" role="img">
+    <div class="logo" aria-label="WordPress logo" role="img">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="32" height="32" aria-hidden="true">
     <circle cx="64" cy="64" r="60" fill="#21759B"/>
     <circle cx="64" cy="64" r="54" fill="#fff"/>
     <path fill="#21759B" d="M64 12a52 52 0 1 0 0 104A52 52 0 0 0 64 12Zm24.3 77.7c-4.7 7.2-12.7 12-24.3 12-6.7 0-12.4-1.8-16.6-4.8l9.8-28.5 10.6 31.1c.4 1 .7 1.8 1.8 1.8s1.5-.7 2-1.8l16.7-44.9c1.2-3.2 1.7-5.8 1.7-8.1 0-3.1-1.1-6.6-3.2-9.4 9.4 3.5 14.5 11.8 14.5 21.6 0 12.6-7.2 22.4-13 30.8ZM47 40.8c1.9 0 4-.3 4-.3.6 0 .7.8.1.9 0 0-1.9.3-4 .3-1.1 0-2.4-.1-3.9-.2l12.2 35.3 7.3-22.1-5-13.2c-1.9-.1-3.8-.2-5.7-.2-2.3 0-4.6.2-6.8.5-.6.1-.7-.8 0-.9 2.3-.4 4.9-.8 7.8-.8Zm6.6-7.2c3.3-.2 6.9-.2 10.2 0 2.2.1 4.4.3 6.4.6.6.1.5.9-.1.9-1.8-.2-3.9-.4-6.3-.5l.2.6 9.1 25.1 5-15c.7-1.8 1-3.7 1-5.3 0-2.1-.4-4-1.4-5.6 6.4 2.4 10.6 7.4 10.6 14.6 0 6.5-3.7 13.9-7.2 20.9l-10.5 20.6L67.5 48.8l-8.6 26-11.4-33c-2.2-.1-4.1-.1-5.6-.1-1.5 0-2.8 0-4 .1 3.9-6.6 11.2-11.2 21.7-12.2Z"/>
   </svg>
-</span>
+</div>
 
-    <span class="logo" aria-label="GitHub logo" role="img">
+    <div class="logo" aria-label="GitHub logo" role="img">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="32" height="32" aria-hidden="true">
     <circle cx="64" cy="64" r="60" fill="#181717"/>
     <path fill="#fff" d="M64 32c-17.7 0-32 14.6-32 32.6 0 14.4 9.1 26.6 21.7 30.9 1.6.3 2.2-.7 2.2-1.6 0-.8 0-3 0-5.8-8.8 2-10.7-3.8-10.7-3.8-1.5-3.9-3.7-4.9-3.7-4.9-3-2.1.2-2 .2-2 3.3.2 5.1 3.5 5.1 3.5 2.9 5.1 7.6 3.7 9.4 2.8.3-2.2 1.1-3.7 2-4.6-7-0.8-14.4-3.6-14.4-16 0-3.6 1.2-6.5 3.3-8.8-.3-.8-1.4-4 .3-8.2 0 0 2.7-.9 8.9 3.4 2.6-.74 5.4-1.12 8.2-1.14 2.8.02 5.6.4 8.2 1.14 6.2-4.3 8.9-3.4 8.9-3.4 1.7 4.2.6 7.4.3 8.2 2.1 2.3 3.3 5.2 3.3 8.8 0 12.4-7.4 15.2-14.5 16 .9.8 2.1 2.6 2.1 5.3 0 3.8 0 6.9 0 7.8 0 .9.6 1.9 2.2 1.6C86.9 91.2 96 79 96 64.6 96 46.6 81.7 32 64 32z"/>
   </svg>
-</span>
+</div>
 
     </div>
     <!-- Certification -->


### PR DESCRIPTION
## Summary
- replace the tech stack anchor placeholders with non-interactive div wrappers in `index.html`
- retarget the CSS selectors so `.tech-logos .logo svg` keeps the same presentation on the new elements

## Testing
- python - <<'PY'
from html.parser import HTMLParser
from pathlib import Path

class LogoParser(HTMLParser):
    def __init__(self):
        super().__init__()
        self.logo_tags = []

    def handle_starttag(self, tag, attrs):
        attrs_dict = dict(attrs)
        classes = attrs_dict.get('class', '').split()
        if 'logo' in classes and 'tech-logos' not in classes:
            self.logo_tags.append((tag, attrs_dict))

html = Path('index.html').read_text(encoding='utf-8')
parser = LogoParser()
parser.feed(html)
print('Logo elements:', len(parser.logo_tags))
focusable = [tag for tag, attrs in parser.logo_tags if tag in {'a', 'button'} or 'tabindex' in attrs]
print('Focusable logos:', len(focusable))
print('Tags seen:', {tag for tag, _ in parser.logo_tags})
PY

------
https://chatgpt.com/codex/tasks/task_e_68cbad41620c83239e541d22a7aca856