### PR TITLE
Add Express backend proxy for OpenAI API

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,3 @@
+# Salin file ini menjadi .env lalu isi nilai OpenAI API key Anda
+OPENAI_API_KEY=sk-xxxx
+PORT=3001

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,52 @@
+# Backend OpenAI Proxy
+
+Backend ringan berbasis Express untuk meneruskan permintaan dari front-end ke OpenAI API secara aman.
+
+## Persiapan
+
+1. Duplikat file `.env.example` menjadi `.env` dan isi nilai `OPENAI_API_KEY` Anda.
+2. Install dependensi dengan menjalankan:
+
+   ```bash
+   npm install
+   ```
+
+## Menjalankan Secara Lokal
+
+```bash
+npm start
+```
+
+Server akan berjalan di `http://localhost:3001` secara default.
+
+### Endpoint
+
+- `POST /api/openai`
+
+  Body (JSON):
+
+  ```json
+  {
+    "prompt": "Tuliskan tagline kreatif",
+    "model": "gpt-3.5-turbo",
+    "temperature": 0.7
+  }
+  ```
+
+  Respons:
+
+  ```json
+  {
+    "success": true,
+    "model": "gpt-3.5-turbo",
+    "created": 1700000000,
+    "message": "Tagline Anda...",
+    "usage": { "prompt_tokens": 12, "completion_tokens": 24, "total_tokens": 36 }
+  }
+  ```
+
+- `GET /health` untuk pengecekan sederhana.
+
+## Deployment
+
+Pastikan environment variable `OPENAI_API_KEY` terset pada platform hosting yang digunakan.

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const cors = require('cors');
+const dotenv = require('dotenv');
+
+const openaiProxy = require('./openaiProxy');
+
+dotenv.config();
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+app.use(cors());
+app.use(express.json({ limit: '1mb' }));
+
+app.post('/api/openai', openaiProxy);
+
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server berjalan pada http://localhost:${PORT}`);
+});

--- a/server/openaiProxy.js
+++ b/server/openaiProxy.js
@@ -1,0 +1,92 @@
+const axios = require('axios');
+
+const MAX_PROMPT_LENGTH = 2000;
+const DISALLOWED_PATTERN = /<\/?script\b/i;
+const OPENAI_CHAT_COMPLETIONS_URL = 'https://api.openai.com/v1/chat/completions';
+
+/**
+ * Validate the prompt and other inputs coming from the client.
+ * @param {string} prompt
+ * @throws {Error} when validation fails
+ */
+function validatePrompt(prompt) {
+  if (typeof prompt !== 'string') {
+    throw new Error('Prompt harus berupa teks.');
+  }
+
+  const trimmedPrompt = prompt.trim();
+
+  if (!trimmedPrompt) {
+    throw new Error('Prompt tidak boleh kosong.');
+  }
+
+  if (trimmedPrompt.length > MAX_PROMPT_LENGTH) {
+    throw new Error(`Prompt terlalu panjang (maksimal ${MAX_PROMPT_LENGTH} karakter).`);
+  }
+
+  if (DISALLOWED_PATTERN.test(trimmedPrompt)) {
+    throw new Error('Prompt mengandung konten yang tidak diizinkan.');
+  }
+
+  return trimmedPrompt;
+}
+
+/**
+ * Express handler that proxies requests to the OpenAI API.
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+module.exports = async function openaiProxy(req, res) {
+  try {
+    if (!process.env.OPENAI_API_KEY) {
+      return res.status(500).json({
+        error: 'Konfigurasi server belum lengkap. OPENAI_API_KEY belum diset.',
+      });
+    }
+
+    const { prompt, model = 'gpt-3.5-turbo', temperature = 0.7 } = req.body || {};
+
+    const sanitizedPrompt = validatePrompt(prompt);
+
+    const response = await axios.post(
+      OPENAI_CHAT_COMPLETIONS_URL,
+      {
+        model,
+        messages: [
+          {
+            role: 'user',
+            content: sanitizedPrompt,
+          },
+        ],
+        temperature,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        timeout: 20000,
+      }
+    );
+
+    const message =
+      response?.data?.choices?.[0]?.message?.content || 'Tidak ada respons dari model.';
+
+    return res.json({
+      success: true,
+      model: response?.data?.model,
+      created: response?.data?.created,
+      message,
+      usage: response?.data?.usage,
+    });
+  } catch (error) {
+    const status = error.response?.status || 500;
+    const errorMessage =
+      error.response?.data?.error?.message || error.message || 'Terjadi kesalahan tak terduga.';
+
+    return res.status(status).json({
+      success: false,
+      error: errorMessage,
+    });
+  }
+};

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "bali-webdeveloper-server",
+  "version": "1.0.0",
+  "description": "Backend proxy for OpenAI requests",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "keywords": [
+    "express",
+    "openai",
+    "proxy"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^1.6.7",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.18.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add Express-based backend with `/api/openai` route that proxies requests to OpenAI using axios and input validation
- expose health-check route and configuration via environment variables with `.env.example`
- document setup and usage steps for running the proxy locally

## Testing
- npm install *(fails: npm registry not accessible from environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbff4f56108323b5cc9fad875889bb