### PR TITLE
Fix responsive grid helper columns

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -75,7 +75,6 @@ ul.clean li{margin:.4rem 0;color:var(--muted)}
 /* Responsive */
 @media (max-width: 820px){
   .hero{grid-template-columns:1fr}
-  .grid.cols-3{grid-template-columns:1fr}
   .nav{display:none}
 }
 
@@ -512,9 +511,16 @@ input, select, textarea {
 }
 
 /* Grid/kartu otomatis turun 1 kolom di layar kecil */
-.grid { display: grid; gap: 16px; grid-template-columns: repeat(3, 1fr); }
-@media (max-width: 992px) { .grid { grid-template-columns: repeat(2, 1fr); } }
-@media (max-width: 576px) { .grid { grid-template-columns: 1fr; } }
+.grid { display: grid; gap: 16px; }
+.grid.cols-2 { grid-template-columns: repeat(2, 1fr); }
+.grid.cols-3 { grid-template-columns: repeat(3, 1fr); }
+@media (max-width: 992px) {
+  .grid.cols-3 { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 576px) {
+  .grid.cols-2,
+  .grid.cols-3 { grid-template-columns: 1fr; }
+}
 
 /* Kartu dengan gambar header yang rapi */
 .card-cover {


### PR DESCRIPTION
## Summary
- remove the base grid column template from the reset block and keep only the shared gap
- add explicit cols-2 and cols-3 modifiers with breakpoints so helper classes keep multiple columns on desktop and collapse correctly on small screens

## Testing
- Manual verification in browser (desktop and mobile breakpoints)


------
https://chatgpt.com/codex/tasks/task_e_68de5cfe164883239b970a771920bf39